### PR TITLE
🧹 Remove commented out code in TimeTrackingService.AddMeter

### DIFF
--- a/src/Budgetr.Shared/Services/TimeTrackingService.cs
+++ b/src/Budgetr.Shared/Services/TimeTrackingService.cs
@@ -433,12 +433,6 @@ public class TimeTrackingService : ITimeTrackingService, IDisposable
             throw new ArgumentException("Meter name must be between 1 and 40 characters.");
         }
 
-        // Check for duplicate factor - REMOVED per user request
-        // if (_account.Meters.Any(m => Math.Abs(m.Factor - factor) < 0.001))
-        // {
-        //     throw new ArgumentException($"A meter with factor {factor} already exists.");
-        // }
-
         var newMeter = new Meter
         {
             Name = name.Trim(),


### PR DESCRIPTION
🎯 **What:** Removed commented out code block in `AddMeter` regarding duplicate factor checks.
💡 **Why:** Cleans up dead code that was removed per user request, improving readability and maintainability.
✅ **Verification:** Verified that tests pass via `dotnet test` and that the change does not impact any functionality since it's only removing commented out lines.
✨ **Result:** A cleaner `TimeTrackingService` class.

---
*PR created automatically by Jules for task [2057367164322340827](https://jules.google.com/task/2057367164322340827) started by @marsop*