### PR TITLE
🧪 Add edge case tests for TimeTrackingService.RenameMeter

### DIFF
--- a/tests/Budgetr.ValidationTest/TimeTrackingServiceTests.cs
+++ b/tests/Budgetr.ValidationTest/TimeTrackingServiceTests.cs
@@ -100,6 +100,52 @@ public class TimeTrackingServiceTests
     }
 
     [Fact]
+    public async Task RenameMeter_EmptyName_Throws()
+    {
+        var sut = await CreateLoadedServiceAsync();
+        var meter = sut.Account.Meters.First();
+
+        Assert.Throws<ArgumentException>(() => sut.RenameMeter(meter.Id, ""));
+        Assert.Throws<ArgumentException>(() => sut.RenameMeter(meter.Id, "   "));
+    }
+
+    [Fact]
+    public async Task RenameMeter_NameTooLong_Throws()
+    {
+        var sut = await CreateLoadedServiceAsync();
+        var meter = sut.Account.Meters.First();
+
+        var tooLongName = new string('A', 41);
+        Assert.Throws<ArgumentException>(() => sut.RenameMeter(meter.Id, tooLongName));
+    }
+
+    [Fact]
+    public async Task RenameMeter_ValidName_RenamesMeter()
+    {
+        var sut = await CreateLoadedServiceAsync();
+        var meter = sut.Account.Meters.First();
+
+        sut.RenameMeter(meter.Id, "New Name");
+
+        Assert.Equal("New Name", meter.Name);
+    }
+
+    [Fact]
+    public async Task RenameMeter_ActiveEvent_UpdatesEventMeterName()
+    {
+        var sut = await CreateLoadedServiceAsync();
+        var meter = sut.Account.Meters.First();
+        sut.ActivateMeter(meter.Id);
+
+        sut.RenameMeter(meter.Id, "Updated Name");
+
+        var activeEvent = sut.GetActiveEvent();
+        Assert.NotNull(activeEvent);
+        Assert.Equal("Updated Name", activeEvent.MeterName);
+        Assert.Equal("Updated Name", meter.Name);
+    }
+
+    [Fact]
     public async Task ActivateMeter_NoPreviousActive_CreatesActiveEvent()
     {
         var sut = await CreateLoadedServiceAsync();


### PR DESCRIPTION
* 🎯 **What:** The testing gap addressed was the lack of unit tests for the `TimeTrackingService.RenameMeter` method, specifically for edge case inputs.
* 📊 **Coverage:** Scenarios that are now tested include renaming with empty or whitespace names (throws exception), names longer than 40 characters (throws exception), a valid string (renames meter successfully), and renaming an active meter (updates the event's meter name).
* ✨ **Result:** The improvement in test coverage ensures the method reliably validates input before altering the state, increasing confidence in future refactoring of this service.

---
*PR created automatically by Jules for task [7576168257522344408](https://jules.google.com/task/7576168257522344408) started by @marsop*